### PR TITLE
Fix cosign signing configuration in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,12 +37,12 @@ checksum:
 signs:
   - cmd: cosign
     stdin: "{{ .Env.COSIGN_PWD }}"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
       - --key=assets/cosign/cosign.key
-      - --output-signature=${signature}
+      - --bundle=${signature}
       - --yes
-      - --bundle=${signature}.bundle
       - ${artifact}
     artifacts: checksum
 


### PR DESCRIPTION
Updated .goreleaser.yaml to use the correct cosign signing flags and output structure. Changed --output-signature to --bundle and added signature filename specification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release signing configuration to change how security signatures are bundled with distributed artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->